### PR TITLE
[FEAT] Rename modes: development->self-hosted, production->valyu

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,45 +8,25 @@
 # ------------------------------------------------------------------------------
 # APP CONFIGURATION
 # ------------------------------------------------------------------------------
-# Set to 'development' or 'production'
-# development = no auth, local SQLite, unlimited queries, Ollama/LM Studio support
-# production = full auth (Sign in with Valyu), Supabase, rate limits
-NEXT_PUBLIC_APP_MODE=development
+# Set to 'self-hosted' or 'valyu'
+# self-hosted = no auth, local SQLite, unlimited queries, Ollama/LM Studio support
+# valyu = full auth (Sign in with Valyu), Supabase, rate limits
+NEXT_PUBLIC_APP_MODE=self-hosted
 
 # Your app URL (use http://localhost:3000 for local development)
 NEXT_PUBLIC_APP_URL=http://localhost:3000
 
 # ------------------------------------------------------------------------------
-# VALYU OAUTH CONFIGURATION (REQUIRED FOR PRODUCTION)
+# VALYU API (REQUIRED)
 # ------------------------------------------------------------------------------
-# "Sign in with Valyu" OAuth 2.1 authentication
-# Users authenticate via Valyu Platform and use their organization's credits
-# Get OAuth credentials from: https://platform.valyu.ai → Settings → OAuth Apps
-
-# Valyu Platform's Supabase URL (OAuth provider)
-NEXT_PUBLIC_VALYU_SUPABASE_URL=https://xxx.supabase.co
-
-# OAuth Client ID (public)
-NEXT_PUBLIC_VALYU_CLIENT_ID=your_oauth_client_id_here
-
-# OAuth Client Secret (KEEP SECRET - server-side only)
-VALYU_CLIENT_SECRET=your_oauth_client_secret_here
-
-# Valyu Platform URL (for userinfo, OAuth proxy)
-VALYU_APP_URL=https://platform.valyu.ai
-
-# ------------------------------------------------------------------------------
-# VALYU API (OPTIONAL - Fallback for Development)
-# ------------------------------------------------------------------------------
-# Server API key for development mode when users aren't authenticated
-# In production, API calls go through Valyu OAuth proxy using user's org credits
+# Server API key for self-hosted mode
 # Get your API key at: https://platform.valyu.ai
 VALYU_API_KEY=valyu_your_api_key_here
 
 # ------------------------------------------------------------------------------
-# OPENAI API (REQUIRED)
+# OPENAI API (OPTIONAL - Fallback for Self-Hosted)
 # ------------------------------------------------------------------------------
-# Used for AI chat responses and natural language understanding
+# Used as fallback for AI chat responses when local models are unavailable
 # Get your API key at: https://platform.openai.com
 OPENAI_API_KEY=sk-your_openai_api_key_here
 
@@ -60,10 +40,10 @@ DAYTONA_API_URL=https://api.daytona.io
 DAYTONA_TARGET=latest
 
 # ------------------------------------------------------------------------------
-# LOCAL LLM CONFIGURATION (OPTIONAL - Development Mode Only)
+# LOCAL LLM CONFIGURATION (RECOMMENDED - Self-Hosted Mode)
 # ------------------------------------------------------------------------------
 # Use Ollama or LM Studio for unlimited, private local AI queries
-# Only used when NEXT_PUBLIC_APP_MODE=development
+# Only used when NEXT_PUBLIC_APP_MODE=self-hosted
 
 # Ollama Configuration (https://ollama.com)
 OLLAMA_BASE_URL=http://localhost:11434
@@ -72,20 +52,43 @@ OLLAMA_BASE_URL=http://localhost:11434
 LMSTUDIO_BASE_URL=http://localhost:1234
 
 # ------------------------------------------------------------------------------
-# APP'S OWN SUPABASE (REQUIRED FOR PRODUCTION)
+# VALYU OAUTH CONFIGURATION (VALYU MODE ONLY)
+# ------------------------------------------------------------------------------
+# NOTE: Valyu OAuth apps will be in general availability soon.
+# Currently client id/secret are not publicly available.
+# Contact contact@valyu.ai if you need access.
+#
+# "Sign in with Valyu" OAuth 2.1 authentication
+# Users authenticate via Valyu Platform and use their organization's credits
+# Get OAuth credentials from: https://platform.valyu.ai -> Settings -> OAuth Apps
+
+# Valyu Platform's Supabase URL (OAuth provider)
+# NEXT_PUBLIC_VALYU_SUPABASE_URL=https://xxx.supabase.co
+
+# OAuth Client ID (public)
+# NEXT_PUBLIC_VALYU_CLIENT_ID=your_oauth_client_id_here
+
+# OAuth Client Secret (KEEP SECRET - server-side only)
+# VALYU_CLIENT_SECRET=your_oauth_client_secret_here
+
+# Valyu Platform URL (for userinfo, OAuth proxy)
+# VALYU_APP_URL=https://platform.valyu.ai
+
+# ------------------------------------------------------------------------------
+# APP'S OWN SUPABASE (VALYU MODE ONLY)
 # ------------------------------------------------------------------------------
 # Your app's Supabase database for chat history, user data, etc.
 # Separate from Valyu Platform's Supabase (which handles OAuth)
-# Get these from: https://supabase.com → Project Settings → API
+# Get these from: https://supabase.com -> Project Settings -> API
 
 # Your Supabase project URL
-NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
+# NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
 
 # Supabase anonymous (public) key
-NEXT_PUBLIC_SUPABASE_ANON_KEY=your_anon_key_here
+# NEXT_PUBLIC_SUPABASE_ANON_KEY=your_anon_key_here
 
 # Supabase service role key (KEEP SECRET - never expose client-side)
-SUPABASE_SERVICE_ROLE_KEY=your_service_role_key_here
+# SUPABASE_SERVICE_ROLE_KEY=your_service_role_key_here
 
 # ------------------------------------------------------------------------------
 # ENTERPRISE FEATURES (OPTIONAL)
@@ -98,22 +101,22 @@ NEXT_PUBLIC_ENTERPRISE=false
 # ------------------------------------------------------------------------------
 # PostHog for analytics and feature flags
 # Get these from: https://posthog.com
-NEXT_PUBLIC_POSTHOG_KEY=your_posthog_key
-NEXT_PUBLIC_POSTHOG_HOST=https://eu.i.posthog.com
+# NEXT_PUBLIC_POSTHOG_KEY=your_posthog_key
+# NEXT_PUBLIC_POSTHOG_HOST=https://eu.i.posthog.com
 
 # ------------------------------------------------------------------------------
 # EXAMPLE CONFIGURATIONS
 # ------------------------------------------------------------------------------
 
-# Development Mode (Easy Setup - No Auth):
-# NEXT_PUBLIC_APP_MODE=development
+# Self-Hosted Mode (Recommended - Easy Setup):
+# NEXT_PUBLIC_APP_MODE=self-hosted
 # VALYU_API_KEY=valyu_xxx
 # DAYTONA_API_KEY=xxx
 # OPENAI_API_KEY=sk-xxx (optional, for fallback)
 # OLLAMA_BASE_URL=http://localhost:11434 (optional)
 
-# Production Mode (Full Setup - Sign in with Valyu):
-# NEXT_PUBLIC_APP_MODE=production
+# Valyu Mode (OAuth Coming Soon - Contact contact@valyu.ai):
+# NEXT_PUBLIC_APP_MODE=valyu
 # NEXT_PUBLIC_APP_URL=https://yourdomain.com
 #
 # # Valyu OAuth

--- a/README.md
+++ b/README.md
@@ -2,25 +2,23 @@
 
 > **Enterprise-grade biomedical research behind a chat interface** - Access PubMed, clinical trials, FDA drug labels, and run complex Python analyses through natural language. Powered by specialized biomedical data APIs.
 
-🚀 **[Try the live demo](https://bio.valyu.ai)**
-
 ![Bio](public/valyu.png)
 
 ## Why Bio?
 
 Traditional biomedical research is fragmented across dozens of databases and platforms. Bio changes everything by providing:
 
-- **🔬 Comprehensive Medical Data** - PubMed articles, ClinicalTrials.gov data, FDA drug labels, and more
-- **🔍 One Unified Search** - Powered by Valyu's specialized biomedical data API
-- **🐍 Advanced Analytics** - Execute Python code in secure Daytona sandboxes for statistical analysis, pharmacokinetic modeling, and custom calculations
-- **📊 Interactive Visualizations** - Beautiful charts and dashboards for clinical data
-- **🌐 Real-Time Intelligence** - Web search integration for breaking medical news
-- **🏠 Local AI Models** - Run with Ollama or LM Studio for unlimited, private queries using your own hardware
-- **🎯 Natural Language** - Just ask questions like you would to a colleague
+- **Comprehensive Medical Data** - PubMed articles, ClinicalTrials.gov data, FDA drug labels, and more
+- **One Unified Search** - Powered by Valyu's specialized biomedical data API
+- **Advanced Analytics** - Execute Python code in secure Daytona sandboxes for statistical analysis, pharmacokinetic modeling, and custom calculations
+- **Interactive Visualizations** - Beautiful charts and dashboards for clinical data
+- **Real-Time Intelligence** - Web search integration for breaking medical news
+- **Local AI Models** - Run with Ollama or LM Studio for unlimited, private queries using your own hardware
+- **Natural Language** - Just ask questions like you would to a colleague
 
 ## Key Features
 
-### 🔥 Powerful Biomedical Tools
+### Powerful Biomedical Tools
 
 - **PubMed & ArXiv Search** - Access to millions of scientific papers and biomedical research
 - **Clinical Trials Database** - Search ClinicalTrials.gov for active and completed trials
@@ -29,46 +27,23 @@ Traditional biomedical research is fragmented across dozens of databases and pla
 - **Interactive Charts** - Visualize clinical data, drug efficacy, patient outcomes
 - **Python Code Execution** - Run pharmacokinetic calculations, statistical analyses, and ML models
 
-### 🛠️ Advanced Tool Calling
+### Advanced Tool Calling
 
 - **Python Code Execution** - Run complex biomedical calculations, statistical tests, and data analysis
 - **Interactive Charts** - Create publication-ready visualizations of clinical data
 - **Multi-Source Research** - Automatically aggregates data from multiple biomedical sources
 - **Export & Share** - Download results, share analyses, and collaborate
 
-## 🚀 Quick Start
+## Quick Start (Self-Hosted)
 
-### Two Modes: Production vs Development
-
-Bio supports two distinct operating modes:
-
-**🌐 Production Mode** (Default)
-- Uses Supabase for authentication and database
-- OpenAI/Vercel AI Gateway for LLM
-- Rate limiting (5 queries/day for free tier)
-- Billing and usage tracking via Polar
-- Full authentication required
-
-**💻 Development Mode** (Recommended for Local Development)
-- **No Supabase required** - Uses local SQLite database
-- **No authentication needed** - Auto-login as dev user
+Self-hosted mode is the recommended way to run Bio. It provides a complete local environment with:
+- **No authentication required** - Auto-login as dev user
+- **Local SQLite database** - No external database setup needed
 - **Unlimited queries** - No rate limits
-- **No billing/tracking** - Polar integration disabled
-- **Works offline** - Complete local development
-- **Ollama/LM Studio integration** - Use local LLMs for privacy and unlimited usage
+- **Ollama/LM Studio support** - Use local LLMs for privacy and unlimited usage
 
 ### Prerequisites
 
-**For Production Mode:**
-- Node.js 18+
-- npm or yarn
-- OpenAI API key
-- Valyu API key (get one at [platform.valyu.ai](https://platform.valyu.ai))
-- Daytona API key (for code execution)
-- Supabase account and project
-- Polar account (for billing)
-
-**For Development Mode (Recommended for getting started):**
 - Node.js 18+
 - npm or yarn
 - Valyu API key (get one at [platform.valyu.ai](https://platform.valyu.ai))
@@ -92,18 +67,17 @@ Bio supports two distinct operating modes:
 
    Create a `.env.local` file in the root directory:
 
-   **For Development Mode (Easy Setup):**
    ```env
-   # Enable Development Mode (No Supabase, No Auth, No Billing)
-   NEXT_PUBLIC_APP_MODE=development
+   # Enable Self-Hosted Mode
+   NEXT_PUBLIC_APP_MODE=self-hosted
 
    # Valyu API Configuration (Required)
    VALYU_API_KEY=your-valyu-api-key
 
    # Daytona Configuration (Required for Python execution)
    DAYTONA_API_KEY=your-daytona-api-key
-   DAYTONA_API_URL=https://api.daytona.io  # Optional
-   DAYTONA_TARGET=latest  # Optional
+   DAYTONA_API_URL=https://api.daytona.io
+   DAYTONA_TARGET=latest
 
    # Local LLM Configuration (Optional - for unlimited, private queries)
    OLLAMA_BASE_URL=http://localhost:11434   # Default Ollama URL
@@ -111,30 +85,6 @@ Bio supports two distinct operating modes:
 
    # OpenAI Configuration (Optional - fallback if local models unavailable)
    OPENAI_API_KEY=your-openai-api-key
-   ```
-
-   **For Production Mode:**
-   ```env
-   # OpenAI Configuration (Required)
-   OPENAI_API_KEY=your-openai-api-key
-
-   # Valyu API Configuration (Required)
-   VALYU_API_KEY=your-valyu-api-key
-
-   # Daytona Configuration (Required)
-   DAYTONA_API_KEY=your-daytona-api-key
-
-   # Supabase Configuration (Required)
-   NEXT_PUBLIC_SUPABASE_URL=your-supabase-url
-   NEXT_PUBLIC_SUPABASE_ANON_KEY=your-supabase-anon-key
-   SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
-
-   # Polar Billing (Required)
-   POLAR_WEBHOOK_SECRET=your-polar-webhook-secret
-   POLAR_UNLIMITED_PRODUCT_ID=your-product-id
-
-   # App Configuration
-   NEXT_PUBLIC_APP_URL=http://localhost:3000
    ```
 
 4. **Run the development server**
@@ -146,14 +96,13 @@ Bio supports two distinct operating modes:
 
    Navigate to [http://localhost:3000](http://localhost:3000)
 
-   - **Development Mode**: You'll be automatically logged in as `dev@localhost`
-   - **Production Mode**: You'll need to sign up/sign in
+   You'll be automatically logged in as `dev@localhost` with full access to all features.
 
-## 🏠 Development Mode Guide
+## Self-Hosted Mode Guide
 
-### What is Development Mode?
+### What is Self-Hosted Mode?
 
-Development mode provides a complete local development environment without any external dependencies beyond the core APIs (Valyu, Daytona). It's perfect for:
+Self-hosted mode provides a complete local environment without any external dependencies beyond the core APIs (Valyu, Daytona). It's perfect for:
 
 - **Local Development** - No Supabase setup required
 - **Offline Work** - All data stored locally in SQLite
@@ -163,12 +112,12 @@ Development mode provides a complete local development environment without any e
 
 ### How It Works
 
-When `NEXT_PUBLIC_APP_MODE=development`:
+When `NEXT_PUBLIC_APP_MODE=self-hosted`:
 
 1. **Local SQLite Database** (`/.local-data/dev.db`)
    - Automatically created on first run
    - Stores chat sessions, messages, charts, and CSVs
-   - Full schema matching production Supabase tables
+   - Full schema matching production tables
    - Easy to inspect with `sqlite3 .local-data/dev.db`
 
 2. **Mock Authentication**
@@ -187,17 +136,11 @@ When `NEXT_PUBLIC_APP_MODE=development`:
    - **OpenAI** (if API key provided) - Fallback if no local models available
    - See local models indicator in top-right corner with provider switching
 
-### Choosing Between Ollama and LM Studio
-
-Bio supports both **Ollama** and **LM Studio** for running local LLMs. Both are free, private, and work offline - choose based on your preference.
-
-**💡 You can use both!** Bio detects both automatically and lets you switch between them with a provider selector in the UI.
-
-### Setting Up Ollama
+### Setting Up Ollama (Recommended)
 
 Ollama provides unlimited, private LLM inference on your local machine - completely free and runs offline!
 
-**🚀 Quick Setup (No Terminal Required):**
+**Quick Setup:**
 
 1. **Download Ollama App**
    - Visit [ollama.com](https://ollama.com) and download the app for your OS
@@ -211,15 +154,12 @@ Ollama provides unlimited, private LLM inference on your local machine - complet
    - That's it! Bio will automatically detect and use it
 
 3. **Use in Bio**
-   - Start the app in development mode
+   - Start the app in self-hosted mode
    - Ollama status indicator appears in top-right corner
    - Shows your available models
    - Click to select which model to use
-   - Icons show capabilities: 🔧 (tools) and 🧠 (reasoning)
 
-**⚡ Advanced Setup (Terminal):**
-
-If you prefer using the terminal:
+**Terminal Setup (Advanced):**
 
 ```bash
 # Install Ollama
@@ -233,128 +173,16 @@ ollama serve
 # Download recommended models
 ollama pull qwen2.5:7b          # Recommended - excellent tool support
 ollama pull llama3.1:8b         # Alternative - good performance
-ollama pull mistral:7b          # Alternative - fast
-ollama pull deepseek-r1:7b      # For reasoning/thinking mode
 ```
-
-**💡 It Just Works:**
-- Bio automatically detects Ollama when it's running
-- No configuration needed
-- Automatically falls back to OpenAI if Ollama is unavailable
-- Switch between models anytime via the local models popup
 
 ### Setting Up LM Studio (Alternative)
 
 LM Studio provides a beautiful GUI for running local LLMs - perfect if you prefer visual interfaces over terminal commands!
 
-**🎨 Easy Setup with GUI:**
-
-1. **Download LM Studio**
-   - Visit [lmstudio.ai](https://lmstudio.ai) and download for your OS
-   - Install and open LM Studio
-   - The app provides a full GUI for managing models
-
-2. **Download Models**
-   - Click on the 🔍 Search icon in LM Studio
-   - Browse available models or search for:
-     - `qwen/qwen3-14b` (recommended - excellent tool support)
-     - `openai/gpt-oss-20b` (OpenAI's open source model with reasoning)
-     - `google/gemma-3-12b` (Google's model with good performance)
-     - `qwen/qwen3-4b-thinking-2507` (reasoning model)
-   - Click download and wait for it to complete
-   - Models are cached locally for offline use
-
-3. **Start the Server**
-   - Click the LM Studio logo in your macOS menu bar (top-right corner)
-   - Select **"Start Server on Port 1234..."**
-
-   ![LM Studio Start Server](public/lmstudio-start.png)
-
-   - Server starts immediately - you'll see the status change to "Running"
-   - That's it! Bio will automatically detect it
-
-4. **Important: Configure Context Window**
-   - ⚠️ **CRITICAL**: This app uses extensive tool descriptions that require adequate context length
-   - In LM Studio, when loading a model:
-     - Click on the model settings (gear icon)
-     - Set **Context Length** to **at least 8192 tokens** (16384+ recommended)
-     - If you see errors like "tokens to keep is greater than context length", your context window is too small
-   - Without sufficient context length, you'll get errors when the AI tries to use tools
-   - This applies to all models in LM Studio - configure each model individually
-
-5. **Use in Bio**
-   - Start the app in development mode
-   - Local models indicator appears in top-right corner
-   - If both Ollama and LM Studio are running, you'll see a provider switcher
-   - Click to select which provider and model to use
-   - Icons show capabilities: 🔧 (tools) and 🧠 (reasoning)
-
-**⚙️ Configuration:**
-- Default URL: `http://localhost:1234`
-- Can be customized in `.env.local`:
-  ```env
-  LMSTUDIO_BASE_URL=http://localhost:1234
-  ```
-
-**💡 LM Studio Features:**
-- Real-time GPU/CPU usage monitoring
-- Easy model comparison and testing
-- Visual prompt builder
-- Chat history within LM Studio
-- No terminal commands needed
-
-### Switching Between Providers
-
-If you have both Ollama and LM Studio running, Bio automatically detects both and shows a beautiful provider switcher in the local models popup:
-
-- **Visual Selection**: Click provider buttons with logos
-- **Seamless Switching**: Switch between providers without reloading
-- **Independent Models**: Each provider shows its own model list
-- **Automatic Detection**: No manual configuration needed
-
-The provider switcher appears automatically when multiple providers are detected!
-
-### Model Capabilities
-
-Not all models support all features. Here's what works:
-
-**Tool Calling Support** (Execute Python, search databases, create charts):
-- ✅ qwen2.5, qwen3, deepseek-r1, deepseek-v3
-- ✅ llama3.1, llama3.2, llama3.3
-- ✅ mistral, mistral-nemo, mistral-small
-- ✅ See full list in Ollama popup (wrench icon)
-
-**Thinking/Reasoning Support** (Show reasoning steps):
-- ✅ deepseek-r1, qwen3, magistral
-- ✅ gpt-oss, cogito
-- ✅ See full list in Ollama popup (brain icon)
-
-**What happens if model lacks tool support?**
-- You'll see a friendly dialog explaining limitations
-- Can continue with text-only responses
-- Or switch to a different model that supports tools
-
-### Development Mode Features
-
-✅ **Full Chat History**
-- All conversations saved to local SQLite
-- Persists across restarts
-- View/delete old sessions
-
-✅ **Charts & Visualizations**
-- Created charts saved locally
-- Retrievable via markdown syntax
-- Rendered from local database
-
-✅ **CSV Data Tables**
-- Generated CSVs stored in SQLite
-- Inline table rendering
-- Full data persistence
-
-✅ **No Hidden Costs**
-- No OpenAI API usage (when using Ollama)
-- No Supabase database costs
-- No authentication service costs
+1. **Download LM Studio** from [lmstudio.ai](https://lmstudio.ai)
+2. **Download Models** - Search for `qwen/qwen3-14b` or `google/gemma-3-12b`
+3. **Start the Server** - Click LM Studio menu bar icon -> "Start Server on Port 1234..."
+4. **Configure Context Window** - Set to at least 8192 tokens (16384+ recommended)
 
 ### Managing Local Database
 
@@ -372,272 +200,19 @@ rm -rf .local-data/
 # Database recreated on next app start
 ```
 
-**Backup Database:**
-```bash
-cp -r .local-data/ .local-data-backup/
-```
+## Valyu Mode (OAuth Coming Soon)
 
-### Switching Between Modes
+> **Note:** Valyu OAuth apps will be in general availability soon. Currently client id/secret are not publicly available. Contact contact@valyu.ai if you need access.
 
-**Development → Production:**
-1. Remove/comment `NEXT_PUBLIC_APP_MODE=development`
-2. Add all Supabase and Polar environment variables
-3. Restart server
+Valyu mode provides:
+- Full authentication via Valyu Platform OAuth
+- Supabase for persistent data storage
+- Usage tracking and billing via Valyu Platform
+- Rate limiting based on subscription tier
 
-**Production → Development:**
-1. Add `NEXT_PUBLIC_APP_MODE=development`
-2. Restart server
-3. Local database automatically created
+For Valyu mode setup, set `NEXT_PUBLIC_APP_MODE=valyu` and configure the OAuth credentials. See `.env.example` for the full list of required variables.
 
-**Note:** Your production Supabase data and local SQLite data are completely separate. Switching modes doesn't migrate data.
-
-### Troubleshooting Development Mode
-
-**Sidebar won't open on homepage:**
-- Fixed! Sidebar now respects dock setting even on homepage
-
-**Local models not detected:**
-- **Ollama**: Make sure Ollama is running: `ollama serve`
-  - Check Ollama URL in `.env.local` (default: `http://localhost:11434`)
-  - Verify models are installed: `ollama list`
-- **LM Studio**: Click LM Studio menu bar icon → "Start Server on Port 1234..."
-  - Check LM Studio URL in `.env.local` (default: `http://localhost:1234`)
-  - Verify at least one model is downloaded in LM Studio
-  - Server must be running for Bio to detect it
-
-**Database errors:**
-- Delete and recreate: `rm -rf .local-data/`
-- Check file permissions in `.local-data/` directory
-
-**Auth errors:**
-- Verify `NEXT_PUBLIC_APP_MODE=development` is set
-- Clear browser localStorage and cache
-- Restart dev server
-
-## Production Deployment Guide
-
-This guide walks you through setting up Bio for production with full authentication, billing, and database functionality.
-
-### 1. Get API Keys
-
-#### Valyu API (Required)
-
-Valyu provides specialized biomedical data - PubMed articles, clinical trials, FDA drug labels, and more. Without this API key, the app cannot access biomedical data.
-
-1. Go to [platform.valyu.ai](https://platform.valyu.ai)
-2. Sign up for an account
-3. Navigate to API Keys section
-4. Create a new API key
-5. Copy your API key (starts with `valyu_`)
-
-#### OpenAI API (Required)
-
-Used for AI chat responses, natural language understanding, and function calling.
-
-1. Go to [platform.openai.com](https://platform.openai.com)
-2. Create an account or sign in
-3. Navigate to API keys
-4. Create a new secret key
-5. Copy the key (starts with `sk-`)
-
-#### Daytona API (Required)
-
-Used for secure Python code execution, enabling data analysis, visualizations, and statistical calculations.
-
-1. Go to [daytona.io](https://daytona.io)
-2. Sign up for an account
-3. Get your API key from the dashboard
-4. Copy the key
-
-### 2. Set Up Supabase Database
-
-#### Create Supabase Project
-
-1. Go to [supabase.com](https://supabase.com)
-2. Create a new project
-3. Wait for the project to be provisioned (2-3 minutes)
-4. Go to Project Settings → API
-5. Copy these values:
-   - `Project URL` → `NEXT_PUBLIC_SUPABASE_URL`
-   - `anon public` key → `NEXT_PUBLIC_SUPABASE_ANON_KEY`
-   - `service_role` key → `SUPABASE_SERVICE_ROLE_KEY` (keep this secret!)
-
-#### Create Database Tables
-
-1. In Supabase Dashboard, go to **SQL Editor**
-2. Click **New Query**
-3. Copy the contents of [`supabase/schema.sql`](supabase/schema.sql) and run it
-
-#### Set Up Row Level Security
-
-1. In the SQL Editor, create another new query
-2. Copy the contents of [`supabase/policies.sql`](supabase/policies.sql) and run it
-
-#### Configure Authentication
-
-1. Go to **Authentication** → **Providers** in Supabase
-2. Enable **Email** provider (enabled by default)
-3. **Optional:** Enable OAuth providers (Google, GitHub, etc.)
-   - For Google: Add OAuth credentials from Google Cloud Console
-   - For GitHub: Add OAuth app credentials from GitHub Settings
-
-4. Go to **Authentication** → **URL Configuration**
-5. Add your site URL and redirect URLs:
-   - Site URL: `https://yourdomain.com` (or `http://localhost:3000` for testing)
-   - Redirect URLs: `https://yourdomain.com/auth/callback`
-
-### 3. Set Up Polar Billing (Optional)
-
-Polar provides subscription billing and payments.
-
-1. Go to [polar.sh](https://polar.sh)
-2. Create an account
-3. Create your products:
-   - **Pay Per Use** plan (e.g., $9.99/month)
-   - **Unlimited** plan (e.g., $49.99/month)
-4. Copy the Product IDs
-5. Go to Settings → Webhooks
-6. Create a webhook:
-   - URL: `https://yourdomain.com/api/webhooks/polar`
-   - Events: Select all `customer.*` and `subscription.*` events
-7. Copy the webhook secret
-
-**If you don't want billing:**
-- Skip this section
-- Remove billing UI from the codebase
-- All users will have unlimited access
-
-### 4. Configure Environment Variables
-
-Create `.env.local` in your project root:
-
-```env
-# App Configuration
-NEXT_PUBLIC_APP_MODE=production
-NEXT_PUBLIC_APP_URL=https://yourdomain.com
-
-# Valyu API (Required - powers all biomedical data)
-# Get yours at: https://platform.valyu.ai
-VALYU_API_KEY=valyu_xxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-
-# OpenAI Configuration
-OPENAI_API_KEY=sk-xxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-
-# Daytona Configuration (Code Execution)
-DAYTONA_API_KEY=your-daytona-api-key
-DAYTONA_API_URL=https://api.daytona.io
-DAYTONA_TARGET=latest
-
-# Supabase Configuration
-NEXT_PUBLIC_SUPABASE_URL=https://xxxxxxxxxxxxx.supabase.co
-NEXT_PUBLIC_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
-SUPABASE_SERVICE_ROLE_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
-
-# Polar Billing (Optional - remove if not using billing)
-POLAR_WEBHOOK_SECRET=whsec_xxxxxxxxxxxxxxxxxxxxx
-POLAR_UNLIMITED_PRODUCT_ID=prod_xxxxxxxxxxxxxxxxxxxxx
-```
-
-### 5. Deploy to Production
-
-#### Deploy to Vercel (Recommended)
-
-1. Push your code to GitHub
-2. Go to [vercel.com](https://vercel.com)
-3. Import your repository
-4. Add all environment variables from `.env.local`
-5. Deploy!
-
-**Important Vercel Settings:**
-- Framework Preset: Next.js
-- Node.js Version: 18.x or higher
-- Build Command: `npm run build`
-- Output Directory: `.next`
-
-#### Other Deployment Options
-
-- **Netlify**: Similar to Vercel
-- **Railway**: Good for full-stack apps
-- **Self-hosted**: Use Docker with PM2 or similar
-
-### 6. Post-Deployment Setup
-
-1. **Test Authentication:**
-   - Visit your site
-   - Try signing up with email
-   - Check that user appears in Supabase Users table
-
-2. **Test Polar Webhooks:**
-   - Subscribe to a plan
-   - Check Supabase users table for `subscription_tier` update
-   - Check Polar dashboard for webhook delivery
-
-3. **Test Biomedical Data:**
-   - Ask a question like "What are recent clinical trials for melanoma?"
-   - Verify Valyu API is returning data
-   - Check that charts and CSVs are saving to database
-
-### 7. Troubleshooting
-
-**Authentication Issues:**
-- Verify Supabase URL and keys are correct
-- Check redirect URLs in Supabase dashboard
-- Clear browser cookies/localStorage and try again
-
-**Database Errors:**
-- Verify all tables were created successfully
-- Check RLS policies are enabled
-- Review Supabase logs for detailed errors
-
-**Billing Not Working:**
-- Verify Polar webhook secret is correct
-- Check Polar dashboard for webhook delivery status
-- Review app logs for webhook processing errors
-
-**No Biomedical Data:**
-- Verify Valyu API key is set correctly in environment variables
-- Check Valyu dashboard for API usage/errors
-- Test API key with a curl request to Valyu
-
-**Rate Limiting:**
-- Check `user_rate_limits` table in Supabase
-- Verify user's subscription tier is set correctly
-- Review rate limit logic in `/api/rate-limit`
-
-### 8. Security Best Practices
-
-**Do:**
-- Keep `SUPABASE_SERVICE_ROLE_KEY` secret (never expose client-side)
-- Use environment variables for all secrets
-- Enable RLS on all Supabase tables
-- Regularly rotate API keys
-- Use HTTPS in production
-- Enable Supabase Auth rate limiting
-
-**Don't:**
-- Commit `.env.local` to git (add to `.gitignore`)
-- Expose service role keys in client-side code
-- Disable RLS policies
-- Use the same API keys for dev and production
-
-### 9. Monitoring & Maintenance
-
-**Supabase:**
-- Monitor database usage in Supabase dashboard
-- Set up database backups (automatic in paid plan)
-- Review auth logs for suspicious activity
-
-**Polar:**
-- Monitor subscription metrics
-- Handle failed payments
-- Review webhook logs
-
-**Application:**
-- Set up error tracking (Sentry, LogRocket, etc.)
-- Monitor API usage (Valyu, OpenAI, Daytona)
-- Set up uptime monitoring (UptimeRobot, Better Uptime)
-
-## 💡 Example Queries
+## Example Queries
 
 Try these powerful queries to see what Bio can do:
 
@@ -654,7 +229,7 @@ Try these powerful queries to see what Bio can do:
 - Perfect for sensitive patient data analysis
 - Choose your preferred interface: terminal (Ollama) or GUI (LM Studio)
 
-## 🏗️ Architecture
+## Architecture
 
 - **Frontend**: Next.js 15 with App Router, Tailwind CSS, shadcn/ui
 - **AI**: OpenAI GPT-5 with function calling + Ollama/LM Studio for local models
@@ -664,7 +239,7 @@ Try these powerful queries to see what Bio can do:
 - **Real-time**: Streaming responses with Vercel AI SDK
 - **Local Models**: Ollama and LM Studio integration for private, unlimited queries
 
-## 🔒 Security
+## Security
 
 - Secure API key management
 - Sandboxed code execution via Daytona
@@ -672,15 +247,15 @@ Try these powerful queries to see what Bio can do:
 - HTTPS encryption for all API calls
 - HIPAA-compliant architecture (when self-hosted)
 
-## 📝 License
+## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
 
-## 🤝 Contributing
+## Contributing
 
 Contributions are welcome! Please feel free to submit a Pull Request.
 
-## 🙏 Acknowledgments
+## Acknowledgments
 
 - Built with [Valyu](https://platform.valyu.ai) - The unified biomedical data API
 - Powered by [Daytona](https://daytona.io) - Secure code execution
@@ -689,11 +264,11 @@ Contributions are welcome! Please feel free to submit a Pull Request.
 ---
 
 <p align="center">
-  Made with ❤️ for biomedical researchers
+  Made with love for biomedical researchers
 </p>
 
 <p align="center">
-  <a href="https://twitter.com/ValyuNetwork">Twitter</a> •
-  <a href="https://www.linkedin.com/company/valyu-ai">LinkedIn</a> •
+  <a href="https://twitter.com/ValyuNetwork">Twitter</a> -
+  <a href="https://www.linkedin.com/company/valyu-ai">LinkedIn</a> -
   <a href="https://github.com/yorkeccak/bio">GitHub</a>
 </p>

--- a/src/app/api/chat/generate-title/route.ts
+++ b/src/app/api/chat/generate-title/route.ts
@@ -24,13 +24,13 @@ export async function POST(req: Request) {
       });
     }
 
-    const isDevelopment = process.env.NEXT_PUBLIC_APP_MODE === 'development';
+    const isSelfHosted = process.env.NEXT_PUBLIC_APP_MODE === 'self-hosted';
     const localEnabled = req.headers.get('x-ollama-enabled') !== 'false';
     const localProvider = (req.headers.get('x-local-provider') as 'ollama' | 'lmstudio' | null) || 'ollama';
     let selectedModel;
 
-    // Try to use local provider in development mode if enabled
-    if (isDevelopment && localEnabled) {
+    // Try to use local provider in self-hosted mode if enabled
+    if (isSelfHosted && localEnabled) {
       try {
         const ollamaBaseUrl = process.env.OLLAMA_BASE_URL || 'http://localhost:11434';
         const lmstudioBaseUrl = process.env.LMSTUDIO_BASE_URL || 'http://localhost:1234';

--- a/src/app/api/enterprise/inquiry/route.ts
+++ b/src/app/api/enterprise/inquiry/route.ts
@@ -2,7 +2,8 @@ import { NextRequest, NextResponse } from 'next/server';
 import { Resend } from 'resend';
 import { EnterpriseInquiryEmail } from '@/lib/email-templates/enterprise-inquiry';
 
-const resend = new Resend(process.env.RESEND_API_KEY);
+// Lazy initialize Resend to avoid build-time errors
+const getResend = () => new Resend(process.env.RESEND_API_KEY);
 
 const ENTERPRISE_RECIPIENTS = [
   'harvey@valyu.ai',
@@ -56,7 +57,7 @@ export async function POST(req: NextRequest) {
     });
 
     // Send email to Valyu team
-    await resend.emails.send({
+    await getResend().emails.send({
       from: 'Bio Enterprise <support@valyu.ai>',
       to: ENTERPRISE_RECIPIENTS,
       replyTo: contactEmail,

--- a/src/app/api/lmstudio-status/route.ts
+++ b/src/app/api/lmstudio-status/route.ts
@@ -15,14 +15,14 @@ interface LMStudioModelsResponse {
 }
 
 export async function GET() {
-  const isDevelopment = process.env.NEXT_PUBLIC_APP_MODE === 'development';
+  const isSelfHosted = process.env.NEXT_PUBLIC_APP_MODE === 'self-hosted';
 
-  if (!isDevelopment) {
+  if (!isSelfHosted) {
     return NextResponse.json({
       connected: false,
       available: false,
-      mode: 'production' as const,
-      message: 'LM Studio is only available in development mode'
+      mode: 'valyu' as const,
+      message: 'LM Studio is only available in self-hosted mode'
     });
   }
 
@@ -59,7 +59,7 @@ export async function GET() {
     return NextResponse.json({
       connected: true,
       available: true,
-      mode: 'development' as const,
+      mode: 'self-hosted' as const,
       baseUrl,
       models,
       message: models.length > 0
@@ -72,7 +72,7 @@ export async function GET() {
         return NextResponse.json({
           connected: false,
           available: true,
-          mode: 'development' as const,
+          mode: 'self-hosted' as const,
           message: 'LM Studio connection timeout (5s). Make sure LM Studio server is running.',
           error: 'Connection timeout',
         });
@@ -82,7 +82,7 @@ export async function GET() {
         return NextResponse.json({
           connected: false,
           available: true,
-          mode: 'development' as const,
+          mode: 'self-hosted' as const,
           message: 'LM Studio server is not running. Start the server in LM Studio.',
           error: 'Connection refused',
         });
@@ -91,7 +91,7 @@ export async function GET() {
       return NextResponse.json({
         connected: false,
         available: true,
-        mode: 'development' as const,
+        mode: 'self-hosted' as const,
         message: `Failed to connect to LM Studio: ${error.message}`,
         error: error.message,
       });
@@ -100,7 +100,7 @@ export async function GET() {
     return NextResponse.json({
       connected: false,
       available: true,
-      mode: 'development' as const,
+      mode: 'self-hosted' as const,
       message: 'Unknown error connecting to LM Studio',
       error: 'Unknown error',
     });

--- a/src/app/api/ollama-status/route.ts
+++ b/src/app/api/ollama-status/route.ts
@@ -2,15 +2,15 @@ import { NextRequest, NextResponse } from 'next/server';
 
 export async function GET(request: NextRequest) {
   try {
-    // Check if we're in development mode with Ollama support
-    const isDevelopment = process.env.NEXT_PUBLIC_APP_MODE === 'development';
-    
-    if (!isDevelopment) {
+    // Check if we're in self-hosted mode with Ollama support
+    const isSelfHosted = process.env.NEXT_PUBLIC_APP_MODE === 'self-hosted';
+
+    if (!isSelfHosted) {
       return NextResponse.json({
         connected: false,
         available: false,
-        message: 'Ollama is only available in development mode',
-        mode: 'production'
+        message: 'Ollama is only available in self-hosted mode',
+        mode: 'valyu'
       });
     }
 
@@ -38,7 +38,7 @@ export async function GET(request: NextRequest) {
         return NextResponse.json({
           connected: true,
           available: true,
-          mode: 'development',
+          mode: 'self-hosted',
           baseUrl: ollamaBaseUrl,
           models: models.map((model: any) => ({
             name: model.name,
@@ -51,7 +51,7 @@ export async function GET(request: NextRequest) {
         return NextResponse.json({
           connected: false,
           available: true,
-          mode: 'development',
+          mode: 'self-hosted',
           baseUrl: ollamaBaseUrl,
           models: [],
           message: `Ollama server responded with status ${response.status}`,
@@ -64,7 +64,7 @@ export async function GET(request: NextRequest) {
         return NextResponse.json({
           connected: false,
           available: true,
-          mode: 'development',
+          mode: 'self-hosted',
           baseUrl: ollamaBaseUrl,
           models: [],
           message: 'Connection to Ollama timed out (5s)',
@@ -74,7 +74,7 @@ export async function GET(request: NextRequest) {
         return NextResponse.json({
           connected: false,
           available: true,
-          mode: 'development',
+          mode: 'self-hosted',
           baseUrl: ollamaBaseUrl,
           models: [],
           message: 'Could not connect to Ollama server. Is it running?',
@@ -84,7 +84,7 @@ export async function GET(request: NextRequest) {
         return NextResponse.json({
           connected: false,
           available: true,
-          mode: 'development',
+          mode: 'self-hosted',
           baseUrl: ollamaBaseUrl,
           models: [],
           message: 'Unexpected error connecting to Ollama',
@@ -96,7 +96,7 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({
       connected: false,
       available: false,
-      mode: process.env.APP_MODE || 'production',
+      mode: process.env.APP_MODE || 'valyu',
       message: 'Internal server error',
       error: error.message
     }, { status: 500 });

--- a/src/components/chat-interface.tsx
+++ b/src/components/chat-interface.tsx
@@ -1702,8 +1702,8 @@ export function ChatInterface({
           'Authorization': `Bearer ${session?.access_token}`
         };
 
-        // Add Ollama preference header if in development mode
-        if (typeof window !== 'undefined' && process.env.NEXT_PUBLIC_APP_MODE === 'development') {
+        // Add Ollama preference header if in self-hosted mode
+        if (typeof window !== 'undefined' && process.env.NEXT_PUBLIC_APP_MODE === 'self-hosted') {
           const ollamaEnabled = localStorage.getItem('ollama-enabled');
           if (ollamaEnabled !== null) {
             titleHeaders['x-ollama-enabled'] = ollamaEnabled;
@@ -1751,8 +1751,8 @@ export function ChatInterface({
           headers['x-ollama-model'] = selectedModel;
         }
 
-        // Check if local provider is enabled in localStorage (only in development mode)
-        if (typeof window !== 'undefined' && process.env.NEXT_PUBLIC_APP_MODE === 'development') {
+        // Check if local provider is enabled in localStorage (only in self-hosted mode)
+        if (typeof window !== 'undefined' && process.env.NEXT_PUBLIC_APP_MODE === 'self-hosted') {
           const localEnabled = localStorage.getItem('ollama-enabled');
           if (localEnabled !== null) {
             headers['x-ollama-enabled'] = localEnabled;

--- a/src/components/enterprise/enterprise-banner.tsx
+++ b/src/components/enterprise/enterprise-banner.tsx
@@ -7,8 +7,8 @@ import { EnterpriseContactModal } from './enterprise-contact-modal';
 export function EnterpriseBanner() {
   const [showModal, setShowModal] = useState(false);
 
-  // Hide in development mode or if enterprise features disabled
-  if (process.env.NEXT_PUBLIC_APP_MODE === 'development' || process.env.NEXT_PUBLIC_ENTERPRISE !== 'true') {
+  // Hide in self-hosted mode or if enterprise features disabled
+  if (process.env.NEXT_PUBLIC_APP_MODE === 'self-hosted' || process.env.NEXT_PUBLIC_ENTERPRISE !== 'true') {
     return null;
   }
 

--- a/src/components/local-model-status.tsx
+++ b/src/components/local-model-status.tsx
@@ -15,7 +15,7 @@ interface LocalModel {
 interface ProviderStatus {
   connected: boolean;
   available: boolean;
-  mode: 'development' | 'production';
+  mode: 'self-hosted' | 'valyu';
   baseUrl?: string;
   models?: LocalModel[];
   message: string;
@@ -61,7 +61,7 @@ export function LocalModelStatus() {
       return {
         connected: false,
         available: false,
-        mode: 'production' as const,
+        mode: 'valyu' as const,
         message: `Failed to check ${provider} status`,
         error: error instanceof Error ? error.message : 'Unknown error'
       };
@@ -84,8 +84,8 @@ export function LocalModelStatus() {
   };
 
   useEffect(() => {
-    // Only check provider status in development mode
-    if (process.env.NEXT_PUBLIC_APP_MODE !== "development") {
+    // Only check provider status in self-hosted mode
+    if (process.env.NEXT_PUBLIC_APP_MODE !== "self-hosted") {
       return;
     }
     checkBothProviders();
@@ -100,7 +100,7 @@ export function LocalModelStatus() {
     }
   }, [isEnabled]);
 
-  if (process.env.NEXT_PUBLIC_APP_MODE !== "development") {
+  if (process.env.NEXT_PUBLIC_APP_MODE !== "self-hosted") {
     return null;
   }
 

--- a/src/components/ollama-status-indicator.tsx
+++ b/src/components/ollama-status-indicator.tsx
@@ -9,7 +9,7 @@ import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
 interface OllamaStatus {
   connected: boolean;
   available: boolean;
-  mode: 'development' | 'production';
+  mode: 'self-hosted' | 'valyu';
   baseUrl?: string;
   models?: Array<{
     name: string;
@@ -37,7 +37,7 @@ export function OllamaStatusIndicator({ hasMessages = false }: { hasMessages?: b
       setStatus({
         connected: false,
         available: false,
-        mode: 'production',
+        mode: 'valyu',
         message: 'Failed to check Ollama status',
         error: error instanceof Error ? error.message : 'Unknown error'
       });
@@ -47,8 +47,8 @@ export function OllamaStatusIndicator({ hasMessages = false }: { hasMessages?: b
   };
 
   useEffect(() => {
-    // Only check Ollama status in development mode
-    if (process.env.NEXT_PUBLIC_APP_MODE === 'development') {
+    // Only check Ollama status in self-hosted mode
+    if (process.env.NEXT_PUBLIC_APP_MODE === 'self-hosted') {
       checkOllamaStatus();
 
       // Check status every 30 seconds
@@ -59,7 +59,7 @@ export function OllamaStatusIndicator({ hasMessages = false }: { hasMessages?: b
 
   // Separate useEffect for initial dialog
   useEffect(() => {
-    if (process.env.NEXT_PUBLIC_APP_MODE === 'development' && status) {
+    if (process.env.NEXT_PUBLIC_APP_MODE === 'self-hosted' && status) {
       const hasShownDialog = localStorage.getItem('ollama-dialog-shown');
       if (!hasShownDialog && !status.connected && status.available) {
         const timer = setTimeout(() => {
@@ -71,13 +71,13 @@ export function OllamaStatusIndicator({ hasMessages = false }: { hasMessages?: b
     }
   }, [status]);
 
-  // Don't render anything in production mode
-  if (process.env.NEXT_PUBLIC_APP_MODE === 'production') {
+  // Don't render anything in valyu mode
+  if (process.env.NEXT_PUBLIC_APP_MODE === 'valyu') {
     return null;
   }
 
-  if (!status || status.mode === 'production') {
-    return null; // Don't show in production mode
+  if (!status || status.mode === 'valyu') {
+    return null; // Don't show in valyu mode
   }
 
   const formatModelSize = (bytes: number) => {

--- a/src/components/ollama-status-wrapper.tsx
+++ b/src/components/ollama-status-wrapper.tsx
@@ -7,8 +7,8 @@ interface OllamaStatusWrapperProps {
 }
 
 export function OllamaStatusWrapper({ hasMessages }: OllamaStatusWrapperProps) {
-  // Only render the indicator in development mode
-  if (process.env.NEXT_PUBLIC_APP_MODE !== 'development') {
+  // Only render the indicator in self-hosted mode
+  if (process.env.NEXT_PUBLIC_APP_MODE !== 'self-hosted') {
     return null;
   }
 

--- a/src/components/ollama-status.tsx
+++ b/src/components/ollama-status.tsx
@@ -88,8 +88,8 @@ const OllamaStatus = () => {
     }
   }, [isEnabled]);
 
-  // Only show in development mode
-  if (process.env.NEXT_PUBLIC_APP_MODE !== "development") {
+  // Only show in self-hosted mode
+  if (process.env.NEXT_PUBLIC_APP_MODE !== "self-hosted") {
     return null;
   }
 

--- a/src/components/providers/provider-selector.tsx
+++ b/src/components/providers/provider-selector.tsx
@@ -101,8 +101,8 @@ export function ProviderSelector() {
   };
 
   useEffect(() => {
-    // Only check provider status in development mode
-    if (process.env.NEXT_PUBLIC_APP_MODE !== "development") {
+    // Only check provider status in self-hosted mode
+    if (process.env.NEXT_PUBLIC_APP_MODE !== "self-hosted") {
       return;
     }
     checkBothProviders();

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -351,7 +351,7 @@ export function Sidebar({
               {/* Divider */}
               {user && !isDevelopment && <div className="w-10 h-px bg-gradient-to-r from-transparent via-gray-300 dark:via-gray-600 to-transparent my-1" />}
 
-              {/* Credits/Billing - Link to Valyu Platform - Hidden in development mode */}
+              {/* Credits/Billing - Link to Valyu Platform - Hidden in self-hosted mode */}
               {user && !isDevelopment && isAuthenticated && (
                 <div className="relative group/tooltip">
                   <button

--- a/src/hooks/use-subscription.ts
+++ b/src/hooks/use-subscription.ts
@@ -24,10 +24,10 @@ export function useSubscription(): UserSubscription {
   const valyuAccessToken = useAuthStore((state) => state.valyuAccessToken);
   const creditsAvailable = useAuthStore((state) => state.creditsAvailable);
 
-  // Development mode bypass - grant all permissions
-  const isDevelopment = process.env.NEXT_PUBLIC_APP_MODE === 'development';
+  // Self-hosted mode bypass - grant all permissions
+  const isSelfHosted = process.env.NEXT_PUBLIC_APP_MODE === 'self-hosted';
 
-  if (isDevelopment) {
+  if (isSelfHosted) {
     return {
       tier: 'authenticated',
       status: 'active',

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,11 +1,11 @@
 /**
- * Unified database interface that switches between Supabase (production)
- * and SQLite (development) based on NEXT_PUBLIC_APP_MODE
+ * Unified database interface that switches between Supabase (valyu mode)
+ * and SQLite (self-hosted mode) based on NEXT_PUBLIC_APP_MODE
  */
 
 import { createClient as createSupabaseClient } from "@/utils/supabase/server";
 import { getLocalDb, DEV_USER_ID } from "./local-db/client";
-import { getDevUser, isDevelopmentMode } from "./local-db/local-auth";
+import { getDevUser, isSelfHostedMode } from "./local-db/local-auth";
 import { eq, desc, and } from "drizzle-orm";
 import * as schema from "./local-db/schema";
 
@@ -14,7 +14,7 @@ import * as schema from "./local-db/schema";
 // ============================================================================
 
 export async function getUser() {
-  if (isDevelopmentMode()) {
+  if (isSelfHostedMode()) {
     return { data: { user: getDevUser() }, error: null };
   }
 
@@ -23,7 +23,7 @@ export async function getUser() {
 }
 
 export async function getSession() {
-  if (isDevelopmentMode()) {
+  if (isSelfHostedMode()) {
     return {
       data: {
         session: {
@@ -44,7 +44,7 @@ export async function getSession() {
 // ============================================================================
 
 export async function getUserProfile(userId: string) {
-  if (isDevelopmentMode()) {
+  if (isSelfHostedMode()) {
     const db = getLocalDb();
     const user = await db.query.users.findFirst({
       where: eq(schema.users.id, userId),
@@ -66,7 +66,7 @@ export async function getUserProfile(userId: string) {
 // ============================================================================
 
 export async function getUserRateLimit(userId: string) {
-  if (isDevelopmentMode()) {
+  if (isSelfHostedMode()) {
     const db = getLocalDb();
     const rateLimit = await db.query.userRateLimits.findFirst({
       where: eq(schema.userRateLimits.userId, userId),
@@ -87,7 +87,7 @@ export async function updateUserRateLimit(
   userId: string,
   updates: { usage_count?: number; reset_date?: string; last_request_at?: Date }
 ) {
-  if (isDevelopmentMode()) {
+  if (isSelfHostedMode()) {
     const db = getLocalDb();
     await db
       .update(schema.userRateLimits)
@@ -113,7 +113,7 @@ export async function updateUserRateLimit(
 // ============================================================================
 
 export async function getChatSessions(userId: string) {
-  if (isDevelopmentMode()) {
+  if (isSelfHostedMode()) {
     const db = getLocalDb();
     const sessions = await db.query.chatSessions.findMany({
       where: eq(schema.chatSessions.userId, userId),
@@ -132,7 +132,7 @@ export async function getChatSessions(userId: string) {
 }
 
 export async function getChatSession(sessionId: string, userId: string) {
-  if (isDevelopmentMode()) {
+  if (isSelfHostedMode()) {
     const db = getLocalDb();
     const session = await db.query.chatSessions.findFirst({
       where: and(
@@ -158,7 +158,7 @@ export async function createChatSession(session: {
   user_id: string;
   title: string;
 }) {
-  if (isDevelopmentMode()) {
+  if (isSelfHostedMode()) {
     const db = getLocalDb();
     await db.insert(schema.chatSessions).values({
       id: session.id,
@@ -178,7 +178,7 @@ export async function updateChatSession(
   userId: string,
   updates: { title?: string; last_message_at?: Date }
 ) {
-  if (isDevelopmentMode()) {
+  if (isSelfHostedMode()) {
     const db = getLocalDb();
     const updateData: any = {
       updatedAt: new Date(),
@@ -209,7 +209,7 @@ export async function updateChatSession(
 }
 
 export async function deleteChatSession(sessionId: string, userId: string) {
-  if (isDevelopmentMode()) {
+  if (isSelfHostedMode()) {
     const db = getLocalDb();
     await db
       .delete(schema.chatSessions)
@@ -236,7 +236,7 @@ export async function deleteChatSession(sessionId: string, userId: string) {
 // ============================================================================
 
 export async function getChatMessages(sessionId: string) {
-  if (isDevelopmentMode()) {
+  if (isSelfHostedMode()) {
     const db = getLocalDb();
     const messages = await db.query.chatMessages.findMany({
       where: eq(schema.chatMessages.sessionId, sessionId),
@@ -265,7 +265,7 @@ export async function saveChatMessages(
 ) {
   console.log('[DB] saveChatMessages called - sessionId:', sessionId, 'messageCount:', messages.length);
 
-  if (isDevelopmentMode()) {
+  if (isSelfHostedMode()) {
     const db = getLocalDb();
 
     // Delete existing messages
@@ -289,7 +289,7 @@ export async function saveChatMessages(
     return { error: null };
   }
 
-  console.log('[DB] Saving to Supabase (production mode)');
+  console.log('[DB] Saving to Supabase (valyu mode)');
   const supabase = await createSupabaseClient();
 
   // Delete existing messages
@@ -325,7 +325,7 @@ export async function saveChatMessages(
 }
 
 export async function deleteChatMessages(sessionId: string) {
-  if (isDevelopmentMode()) {
+  if (isSelfHostedMode()) {
     const db = getLocalDb();
     await db
       .delete(schema.chatMessages)
@@ -346,7 +346,7 @@ export async function deleteChatMessages(sessionId: string) {
 // ============================================================================
 
 export async function getChart(chartId: string) {
-  if (isDevelopmentMode()) {
+  if (isSelfHostedMode()) {
     const db = getLocalDb();
     const chart = await db.query.charts.findFirst({
       where: eq(schema.charts.id, chartId),
@@ -370,7 +370,7 @@ export async function createChart(chart: {
   session_id: string;
   chart_data: any;
 }) {
-  if (isDevelopmentMode()) {
+  if (isSelfHostedMode()) {
     const db = getLocalDb();
     await db.insert(schema.charts).values({
       id: chart.id,
@@ -392,7 +392,7 @@ export async function createChart(chart: {
 // ============================================================================
 
 export async function getCSV(csvId: string) {
-  if (isDevelopmentMode()) {
+  if (isSelfHostedMode()) {
     const db = getLocalDb();
     const csv = await db.query.csvs.findFirst({
       where: eq(schema.csvs.id, csvId),
@@ -419,7 +419,7 @@ export async function createCSV(csv: {
   headers: string[];
   rows: any[][];
 }) {
-  if (isDevelopmentMode()) {
+  if (isSelfHostedMode()) {
     const db = getLocalDb();
     await db.insert(schema.csvs).values({
       id: csv.id,

--- a/src/lib/local-db/local-auth.ts
+++ b/src/lib/local-db/local-auth.ts
@@ -1,6 +1,6 @@
 import { DEV_USER_ID, DEV_USER_EMAIL } from "./client";
 
-// Mock auth session for development mode
+// Mock auth session for self-hosted mode
 export interface LocalAuthSession {
   user: {
     id: string;
@@ -20,7 +20,7 @@ export function getDevSession(): LocalAuthSession {
   };
 }
 
-// Mock auth user for development mode
+// Mock auth user for self-hosted mode
 export function getDevUser() {
   return {
     id: DEV_USER_ID,
@@ -28,7 +28,7 @@ export function getDevUser() {
   };
 }
 
-// Check if we're in development mode
-export function isDevelopmentMode(): boolean {
-  return process.env.NEXT_PUBLIC_APP_MODE === "development";
+// Check if we're in self-hosted mode
+export function isSelfHostedMode(): boolean {
+  return process.env.NEXT_PUBLIC_APP_MODE === "self-hosted";
 }

--- a/src/lib/tools.ts
+++ b/src/lib/tools.ts
@@ -13,7 +13,7 @@ const VALYU_OAUTH_PROXY_URL = process.env.VALYU_OAUTH_PROXY_URL ||
 
 /**
  * Call Valyu API using OAuth proxy when user token is available
- * Falls back to server API key in development mode or when no token
+ * Falls back to server API key in self-hosted mode or when no token
  */
 async function callValyuApi(
   path: string,

--- a/src/utils/supabase/client-wrapper.ts
+++ b/src/utils/supabase/client-wrapper.ts
@@ -1,6 +1,6 @@
 /**
- * Client-side database wrapper that switches between Supabase (production)
- * and local mock (development) based on NEXT_PUBLIC_APP_MODE
+ * Client-side database wrapper that switches between Supabase (valyu mode)
+ * and local mock (self-hosted mode) based on NEXT_PUBLIC_APP_MODE
  */
 
 import { createClient as createSupabaseClient } from './client';
@@ -9,9 +9,9 @@ import { createClient as createSupabaseClient } from './client';
 const DEV_USER_ID = "dev-user-00000000-0000-0000-0000-000000000000";
 const DEV_USER_EMAIL = "dev@localhost";
 
-const isDevelopment = () => process.env.NEXT_PUBLIC_APP_MODE === 'development';
+const isSelfHosted = () => process.env.NEXT_PUBLIC_APP_MODE === 'self-hosted';
 
-// Mock auth object for development mode
+// Mock auth object for self-hosted mode
 const createDevAuth = () => ({
   getUser: async () => ({
     data: {
@@ -152,8 +152,8 @@ const createDevAuth = () => ({
 });
 
 export function createClient() {
-  if (isDevelopment()) {
-    // Return mock Supabase client for development
+  if (isSelfHosted()) {
+    // Return mock Supabase client for self-hosted mode
     return {
       auth: createDevAuth(),
       // Mock other methods that might be used


### PR DESCRIPTION
## Summary
- Rename app modes for clarity: development -> self-hosted, production -> valyu
- Update all code references, .env.example, and README
- Focus documentation on self-hosted mode as primary usage
- De-emphasize valyu mode (OAuth apps coming to general availability soon)

## Changes
- Rename `isDevelopmentMode()` to `isSelfHostedMode()` in local-auth.ts
- Update `NEXT_PUBLIC_APP_MODE` value checks from "development" to "self-hosted"
- Update `NEXT_PUBLIC_APP_MODE` value checks from "production" to "valyu"
- Update all mode-related comments throughout the codebase
- Update API route responses to use new mode names
- Update .env.example with self-hosted focus and OAuth coming soon note
- Rewrite README to focus on self-hosted mode as recommended setup

## Files Modified
- `src/lib/local-db/local-auth.ts` - Core function rename
- `src/lib/db.ts` - Import and usage updates
- `src/app/api/chat/route.ts` - Mode checks and comments
- `src/app/api/chat/generate-title/route.ts` - Mode checks
- `src/app/api/ollama-status/route.ts` - Mode checks and responses
- `src/app/api/lmstudio-status/route.ts` - Mode checks and responses
- Various component files - Mode checks in useEffect and conditionals
- `.env.example` - Updated with self-hosted focus
- `README.md` - Rewritten with self-hosted focus

## Test Plan
- [ ] Verify app runs correctly with `NEXT_PUBLIC_APP_MODE=self-hosted`
- [ ] Verify Ollama/LM Studio detection works in self-hosted mode
- [ ] Verify local SQLite database creates and works correctly
- [ ] Verify mock auth works in self-hosted mode

Note: Valyu OAuth apps will be in general availability soon. Contact contact@valyu.ai if you need access now.