### PR TITLE
[FIX] Default to self-hosted mode when APP_MODE not set

### DIFF
--- a/src/lib/local-db/local-auth.ts
+++ b/src/lib/local-db/local-auth.ts
@@ -28,7 +28,7 @@ export function getDevUser() {
   };
 }
 
-// Check if we're in self-hosted mode
+// Check if we're in self-hosted mode (defaults to true if not explicitly set to "valyu")
 export function isSelfHostedMode(): boolean {
-  return process.env.NEXT_PUBLIC_APP_MODE === "self-hosted";
+  return process.env.NEXT_PUBLIC_APP_MODE !== "valyu";
 }


### PR DESCRIPTION
## Summary
- Change default behavior: apps now default to self-hosted mode
- Only switches to valyu mode when explicitly set: `NEXT_PUBLIC_APP_MODE=valyu`
- Users only need `VALYU_API_KEY` to get started - no mode config required