### PR TITLE
Add pharma and healthcare data sources

### DIFF
--- a/src/components/data-source-logos.tsx
+++ b/src/components/data-source-logos.tsx
@@ -334,6 +334,259 @@ response.results.forEach(paper => {
       },
     ],
   },
+  {
+    name: "ChEMBL",
+    src: "/web.svg",
+    description: "Bioactive compounds and drug discovery data",
+    snippets: [
+      {
+        language: "Python",
+        code: `from valyu import Valyu
+
+valyu = Valyu(api_key="<your_api_key>")
+
+# Search for bioactive compounds
+response = valyu.search(
+    "EGFR kinase inhibitors bioactivity",
+    included_sources=["valyu/valyu-chembl"]
+)
+
+# Get compound details
+for compound in response.results:
+    print(f"Compound: {compound.title}")
+    print(f"Target: {compound.metadata.get('target')}")
+    print(f"Activity: {compound.content[:300]}...")`,
+      },
+      {
+        language: "TypeScript",
+        code: `import { Valyu } from 'valyu';
+
+const valyu = new Valyu({ apiKey: '<your_api_key>' });
+
+// Search for bioactive compounds
+const response = await valyu.search({
+    query: 'EGFR kinase inhibitors bioactivity',
+    includedSources: ['valyu/valyu-chembl'],
+});
+
+// Get compound details
+response.results.forEach(compound => {
+});`,
+      },
+      {
+        language: "cURL",
+        code: `curl -X POST https://api.valyu.ai/v1/deepsearch \\
+  -H "x-api-key: <your_api_key>" \\
+  -H "Content-Type: application/json" \\
+  -d '{
+    "query": "EGFR kinase inhibitors bioactivity",
+    "included_sources": ["valyu/valyu-chembl"]
+  }'`,
+      },
+    ],
+  },
+  {
+    name: "DrugBank",
+    src: "/web.svg",
+    description: "Comprehensive drug database with pharmacology data",
+    snippets: [
+      {
+        language: "Python",
+        code: `from valyu import Valyu
+
+valyu = Valyu(api_key="<your_api_key>")
+
+# Search for drug information
+response = valyu.search(
+    "metformin mechanism of action diabetes",
+    included_sources=["valyu/valyu-drugbank"]
+)
+
+# Get drug details
+for drug in response.results:
+    print(f"Drug: {drug.title}")
+    print(f"Mechanism: {drug.content[:300]}...")`,
+      },
+      {
+        language: "TypeScript",
+        code: `import { Valyu } from 'valyu';
+
+const valyu = new Valyu({ apiKey: '<your_api_key>' });
+
+// Search for drug information
+const response = await valyu.search({
+    query: 'metformin mechanism of action diabetes',
+    includedSources: ['valyu/valyu-drugbank'],
+});
+
+// Get drug details
+response.results.forEach(drug => {
+});`,
+      },
+      {
+        language: "cURL",
+        code: `curl -X POST https://api.valyu.ai/v1/deepsearch \\
+  -H "x-api-key: <your_api_key>" \\
+  -H "Content-Type: application/json" \\
+  -d '{
+    "query": "metformin mechanism of action diabetes",
+    "included_sources": ["valyu/valyu-drugbank"]
+  }'`,
+      },
+    ],
+  },
+  {
+    name: "Open Targets",
+    src: "/web.svg",
+    description: "Drug target validation and disease associations",
+    snippets: [
+      {
+        language: "Python",
+        code: `from valyu import Valyu
+
+valyu = Valyu(api_key="<your_api_key>")
+
+# Search for drug targets
+response = valyu.search(
+    "BRCA1 breast cancer genetic associations",
+    included_sources=["valyu/valyu-open-targets"]
+)
+
+# Get target validation data
+for target in response.results:
+    print(f"Target: {target.title}")
+    print(f"Disease: {target.metadata.get('disease')}")
+    print(f"Evidence: {target.content[:300]}...")`,
+      },
+      {
+        language: "TypeScript",
+        code: `import { Valyu } from 'valyu';
+
+const valyu = new Valyu({ apiKey: '<your_api_key>' });
+
+// Search for drug targets
+const response = await valyu.search({
+    query: 'BRCA1 breast cancer genetic associations',
+    includedSources: ['valyu/valyu-open-targets'],
+});
+
+// Get target validation data
+response.results.forEach(target => {
+});`,
+      },
+      {
+        language: "cURL",
+        code: `curl -X POST https://api.valyu.ai/v1/deepsearch \\
+  -H "x-api-key: <your_api_key>" \\
+  -H "Content-Type: application/json" \\
+  -d '{
+    "query": "BRCA1 breast cancer genetic associations",
+    "included_sources": ["valyu/valyu-open-targets"]
+  }'`,
+      },
+    ],
+  },
+  {
+    name: "NPI Registry",
+    src: "/web.svg",
+    description: "US healthcare provider directory",
+    snippets: [
+      {
+        language: "Python",
+        code: `from valyu import Valyu
+
+valyu = Valyu(api_key="<your_api_key>")
+
+# Search for healthcare providers
+response = valyu.search(
+    "oncology specialists New York",
+    included_sources=["valyu/valyu-npi-registry"]
+)
+
+# Get provider details
+for provider in response.results:
+    print(f"Provider: {provider.title}")
+    print(f"Specialty: {provider.metadata.get('specialty')}")
+    print(f"Location: {provider.content[:200]}...")`,
+      },
+      {
+        language: "TypeScript",
+        code: `import { Valyu } from 'valyu';
+
+const valyu = new Valyu({ apiKey: '<your_api_key>' });
+
+// Search for healthcare providers
+const response = await valyu.search({
+    query: 'oncology specialists New York',
+    includedSources: ['valyu/valyu-npi-registry'],
+});
+
+// Get provider details
+response.results.forEach(provider => {
+});`,
+      },
+      {
+        language: "cURL",
+        code: `curl -X POST https://api.valyu.ai/v1/deepsearch \\
+  -H "x-api-key: <your_api_key>" \\
+  -H "Content-Type: application/json" \\
+  -d '{
+    "query": "oncology specialists New York",
+    "included_sources": ["valyu/valyu-npi-registry"]
+  }'`,
+      },
+    ],
+  },
+  {
+    name: "WHO ICD Codes",
+    src: "/assets/banner/who.png",
+    description: "International Classification of Diseases (ICD-10/11)",
+    snippets: [
+      {
+        language: "Python",
+        code: `from valyu import Valyu
+
+valyu = Valyu(api_key="<your_api_key>")
+
+# Search for ICD codes
+response = valyu.search(
+    "diabetes mellitus type 2 ICD code",
+    included_sources=["valyu/valyu-who-icd"]
+)
+
+# Get ICD code details
+for code in response.results:
+    print(f"Code: {code.title}")
+    print(f"Description: {code.content[:200]}...")`,
+      },
+      {
+        language: "TypeScript",
+        code: `import { Valyu } from 'valyu';
+
+const valyu = new Valyu({ apiKey: '<your_api_key>' });
+
+// Search for ICD codes
+const response = await valyu.search({
+    query: 'diabetes mellitus type 2 ICD code',
+    includedSources: ['valyu/valyu-who-icd'],
+});
+
+// Get ICD code details
+response.results.forEach(code => {
+});`,
+      },
+      {
+        language: "cURL",
+        code: `curl -X POST https://api.valyu.ai/v1/deepsearch \\
+  -H "x-api-key: <your_api_key>" \\
+  -H "Content-Type: application/json" \\
+  -d '{
+    "query": "diabetes mellitus type 2 ICD code",
+    "included_sources": ["valyu/valyu-who-icd"]
+  }'`,
+      },
+    ],
+  },
 ];
 
 const DataSourceLogos = () => {

--- a/src/lib/tools.ts
+++ b/src/lib/tools.ts
@@ -693,6 +693,196 @@ ${execution.result || '(No output produced)'}
       }
     },
   }),
+
+  compoundSearch: tool({
+    description: "Search ChEMBL database for bioactive compounds, drug-like molecules, bioactivity data, and target information. Use for drug discovery, compound screening, and medicinal chemistry research.",
+    inputSchema: z.object({
+      query: z.string().describe('Compound search query (e.g., "kinase inhibitors", "EGFR binding compounds", "aspirin bioactivity")'),
+      maxResults: z.number().min(1).max(20).optional().default(10).describe('Maximum number of results'),
+    }),
+    execute: async ({ query, maxResults }, options) => {
+      const valyuAccessToken = (options as any)?.experimental_context?.valyuAccessToken;
+
+      try {
+        const response = await callValyuApi('/v1/deepsearch', {
+          query,
+          maxNumResults: maxResults || 10,
+          searchType: "proprietary",
+          includedSources: ["valyu/valyu-chembl"],
+          relevanceThreshold: 0.4,
+        }, valyuAccessToken);
+
+        await track("Valyu API Call", {
+          toolType: "compoundSearch",
+          query: query,
+          resultCount: response?.results?.length || 0,
+          usedOAuthProxy: !!valyuAccessToken,
+        });
+
+        return JSON.stringify({
+          type: "compound_search",
+          query: query,
+          resultCount: response?.results?.length || 0,
+          results: response?.results || [],
+          displaySource: 'ChEMBL'
+        }, null, 2);
+      } catch (error) {
+        return `❌ Error searching compounds: ${error instanceof Error ? error.message : 'Unknown error'}`;
+      }
+    },
+  }),
+
+  drugDatabaseSearch: tool({
+    description: "Search DrugBank for comprehensive drug information including mechanisms of action, drug targets, pharmacology, drug-drug interactions, and pharmacokinetics.",
+    inputSchema: z.object({
+      query: z.string().describe('Drug database search query (e.g., "metformin mechanism", "statins interactions", "warfarin pharmacokinetics")'),
+      maxResults: z.number().min(1).max(20).optional().default(10).describe('Maximum number of results'),
+    }),
+    execute: async ({ query, maxResults }, options) => {
+      const valyuAccessToken = (options as any)?.experimental_context?.valyuAccessToken;
+
+      try {
+        const response = await callValyuApi('/v1/deepsearch', {
+          query,
+          maxNumResults: maxResults || 10,
+          searchType: "proprietary",
+          includedSources: ["valyu/valyu-drugbank"],
+          relevanceThreshold: 0.4,
+        }, valyuAccessToken);
+
+        await track("Valyu API Call", {
+          toolType: "drugDatabaseSearch",
+          query: query,
+          resultCount: response?.results?.length || 0,
+          usedOAuthProxy: !!valyuAccessToken,
+        });
+
+        return JSON.stringify({
+          type: "drug_database",
+          query: query,
+          resultCount: response?.results?.length || 0,
+          results: response?.results || [],
+          displaySource: 'DrugBank'
+        }, null, 2);
+      } catch (error) {
+        return `❌ Error searching drug database: ${error instanceof Error ? error.message : 'Unknown error'}`;
+      }
+    },
+  }),
+
+  drugTargetSearch: tool({
+    description: "Search Open Targets for drug target validation data including disease associations, genetic evidence, target tractability, and target-disease relationships.",
+    inputSchema: z.object({
+      query: z.string().describe('Drug target search query (e.g., "BRCA1 cancer associations", "diabetes drug targets", "Alzheimer tractable targets")'),
+      maxResults: z.number().min(1).max(20).optional().default(10).describe('Maximum number of results'),
+    }),
+    execute: async ({ query, maxResults }, options) => {
+      const valyuAccessToken = (options as any)?.experimental_context?.valyuAccessToken;
+
+      try {
+        const response = await callValyuApi('/v1/deepsearch', {
+          query,
+          maxNumResults: maxResults || 10,
+          searchType: "proprietary",
+          includedSources: ["valyu/valyu-open-targets"],
+          relevanceThreshold: 0.4,
+        }, valyuAccessToken);
+
+        await track("Valyu API Call", {
+          toolType: "drugTargetSearch",
+          query: query,
+          resultCount: response?.results?.length || 0,
+          usedOAuthProxy: !!valyuAccessToken,
+        });
+
+        return JSON.stringify({
+          type: "drug_targets",
+          query: query,
+          resultCount: response?.results?.length || 0,
+          results: response?.results || [],
+          displaySource: 'Open Targets'
+        }, null, 2);
+      } catch (error) {
+        return `❌ Error searching drug targets: ${error instanceof Error ? error.message : 'Unknown error'}`;
+      }
+    },
+  }),
+
+  healthcareProviderSearch: tool({
+    description: "Search the US National Provider Identifier (NPI) registry for healthcare provider information including specialties, practice locations, and contact details.",
+    inputSchema: z.object({
+      query: z.string().describe('Healthcare provider search query (e.g., "cardiologist New York", "oncology specialists", "Dr. Smith cardiology")'),
+      maxResults: z.number().min(1).max(20).optional().default(10).describe('Maximum number of results'),
+    }),
+    execute: async ({ query, maxResults }, options) => {
+      const valyuAccessToken = (options as any)?.experimental_context?.valyuAccessToken;
+
+      try {
+        const response = await callValyuApi('/v1/deepsearch', {
+          query,
+          maxNumResults: maxResults || 10,
+          searchType: "proprietary",
+          includedSources: ["valyu/valyu-npi-registry"],
+          relevanceThreshold: 0.4,
+        }, valyuAccessToken);
+
+        await track("Valyu API Call", {
+          toolType: "healthcareProviderSearch",
+          query: query,
+          resultCount: response?.results?.length || 0,
+          usedOAuthProxy: !!valyuAccessToken,
+        });
+
+        return JSON.stringify({
+          type: "healthcare_providers",
+          query: query,
+          resultCount: response?.results?.length || 0,
+          results: response?.results || [],
+          displaySource: 'NPI Registry'
+        }, null, 2);
+      } catch (error) {
+        return `❌ Error searching healthcare providers: ${error instanceof Error ? error.message : 'Unknown error'}`;
+      }
+    },
+  }),
+
+  medicalCodeSearch: tool({
+    description: "Search WHO International Classification of Diseases (ICD-10/ICD-11) codes for diagnosis coding, billing codes, and disease classification.",
+    inputSchema: z.object({
+      query: z.string().describe('Medical code search query (e.g., "diabetes mellitus ICD code", "hypertension classification", "E11 diabetes")'),
+      maxResults: z.number().min(1).max(20).optional().default(10).describe('Maximum number of results'),
+    }),
+    execute: async ({ query, maxResults }, options) => {
+      const valyuAccessToken = (options as any)?.experimental_context?.valyuAccessToken;
+
+      try {
+        const response = await callValyuApi('/v1/deepsearch', {
+          query,
+          maxNumResults: maxResults || 10,
+          searchType: "proprietary",
+          includedSources: ["valyu/valyu-who-icd"],
+          relevanceThreshold: 0.4,
+        }, valyuAccessToken);
+
+        await track("Valyu API Call", {
+          toolType: "medicalCodeSearch",
+          query: query,
+          resultCount: response?.results?.length || 0,
+          usedOAuthProxy: !!valyuAccessToken,
+        });
+
+        return JSON.stringify({
+          type: "medical_codes",
+          query: query,
+          resultCount: response?.results?.length || 0,
+          results: response?.results || [],
+          displaySource: 'WHO ICD'
+        }, null, 2);
+      } catch (error) {
+        return `❌ Error searching medical codes: ${error instanceof Error ? error.message : 'Unknown error'}`;
+      }
+    },
+  }),
 };
 
 // Export with both names for compatibility


### PR DESCRIPTION
## Summary

- Add 5 new specialized search tools for pharma/healthcare data sources:
  - **ChEMBL** - Bioactive compounds, drug-like molecules, bioactivity data
  - **DrugBank** - Drug mechanisms, targets, pharmacology, interactions
  - **Open Targets** - Drug target validation, disease associations, genetic evidence
  - **NPI Registry** - US healthcare provider directory with specialties
  - **WHO ICD** - ICD-10/ICD-11 disease classification codes

- Add code snippets and documentation for each new source in the data source showcase

## Test plan

- [ ] Verify each new search tool returns results when queried
- [ ] Test compound search with ChEMBL for kinase inhibitors
- [ ] Test drug database search with DrugBank for drug interactions
- [ ] Test target search with Open Targets for disease associations
- [ ] Test provider search with NPI registry
- [ ] Test ICD code search for diagnosis codes