### PR TITLE
Fix self-hosted mode auth and default theme

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -79,6 +79,7 @@ export default function RootLayout({
         <ThemeProvider
           attribute="class"
           defaultTheme="light"
+          enableSystem={false}
           disableTransitionOnChange
         >
           <QueryProvider>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -324,7 +324,7 @@ function HomeContent() {
               onMessagesChange={handleMessagesChange}
               onSessionCreated={handleSessionCreated}
               onNewChat={handleNewChat}
-              isAuthenticated={!!valyuAccessToken}
+              isAuthenticated={process.env.NEXT_PUBLIC_APP_MODE === 'self-hosted' || !!valyuAccessToken}
               onShowAuth={() => setShowAuthModal(true)}
             />
           </Suspense>


### PR DESCRIPTION
## Summary
- Fix auth modal showing incorrectly in self-hosted mode by checking APP_MODE before requiring Valyu OAuth
- Set light mode as default by disabling system theme preference override

## Test plan
- [ ] Run app with `NEXT_PUBLIC_APP_MODE=self-hosted`
- [ ] Verify no auth modal appears on load
- [ ] Verify light mode is default theme