### PR TITLE
Update README for open-source clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+<p align="center">
+  <a href="https://github.com/yorkeccak/bio/stargazers"><img src="https://img.shields.io/github/stars/yorkeccak/bio?style=flat&color=yellow" alt="GitHub Stars"></a>
+  <a href="https://github.com/yorkeccak/bio/blob/main/LICENSE"><img src="https://img.shields.io/github/license/yorkeccak/bio" alt="License"></a>
+  <a href="https://github.com/yorkeccak/bio/network/members"><img src="https://img.shields.io/github/forks/yorkeccak/bio?style=flat" alt="Forks"></a>
+  <a href="https://github.com/yorkeccak/bio/graphs/contributors"><img src="https://img.shields.io/github/contributors/yorkeccak/bio" alt="Contributors"></a>
+</p>
+
 # Bio
 
 Try the hosted version [here](https://bio.valyu.ai) 🙌  
@@ -49,9 +56,9 @@ Self-hosted mode is the recommended way to run Bio. It provides a complete local
 ### Prerequisites
 
 - Node.js 18+
-- npm or yarn
+- pnpm (`npm install -g pnpm`)
 - Valyu API key (get one at [platform.valyu.ai](https://platform.valyu.ai))
-- Daytona API key (for code execution)
+- [Daytona](https://www.daytona.io) API key - used for secure sandboxed Python code execution (get one at [app.daytona.io](https://app.daytona.io))
 - [Ollama](https://ollama.com) or [LM Studio](https://lmstudio.ai) installed (optional but recommended)
 
 ### Installation
@@ -64,7 +71,7 @@ Self-hosted mode is the recommended way to run Bio. It provides a complete local
 
 2. **Install dependencies**
    ```bash
-   npm install
+   pnpm install
    ```
 
 3. **Set up environment variables**
@@ -93,7 +100,7 @@ Self-hosted mode is the recommended way to run Bio. It provides a complete local
 
 4. **Run the development server**
    ```bash
-   npm run dev
+   pnpm dev
    ```
 
 5. **Open your browser**
@@ -204,18 +211,6 @@ rm -rf .local-data/
 # Database recreated on next app start
 ```
 
-## Valyu Mode (OAuth Coming Soon)
-
-> **Note:** Valyu OAuth apps will be in general availability soon. Currently client id/secret are not publicly available. Contact contact@valyu.ai if you need access.
-
-Valyu mode provides:
-- Full authentication via Valyu Platform OAuth
-- Supabase for persistent data storage
-- Usage tracking and billing via Valyu Platform
-- Rate limiting based on subscription tier
-
-For Valyu mode setup, set `NEXT_PUBLIC_APP_MODE=valyu` and configure the OAuth credentials. See `.env.example` for the full list of required variables.
-
 ## Example Queries
 
 Try these powerful queries to see what Bio can do:
@@ -236,12 +231,27 @@ Try these powerful queries to see what Bio can do:
 ## Architecture
 
 - **Frontend**: Next.js 15 with App Router, Tailwind CSS, shadcn/ui
-- **AI**: OpenAI GPT-5 with function calling + Ollama/LM Studio for local models
+- **AI**: OpenAI GPT-5.2 with function calling + Ollama/LM Studio for local models
 - **Data**: Valyu API for comprehensive biomedical data
 - **Code Execution**: Daytona sandboxes for secure Python execution
 - **Visualizations**: Recharts for interactive charts
 - **Real-time**: Streaming responses with Vercel AI SDK
 - **Local Models**: Ollama and LM Studio integration for private, unlimited queries
+
+## Deploy to Vercel
+
+The quickest way to get Bio running in production:
+
+1. **Fork this repository** to your GitHub account
+2. **Create a new project** on [vercel.com](https://vercel.com) and import your fork
+3. **Add environment variables** in Vercel project settings (Settings > Environment Variables):
+   - `NEXT_PUBLIC_APP_MODE` = `self-hosted`
+   - `VALYU_API_KEY` = your Valyu API key
+   - `DAYTONA_API_KEY` = your Daytona API key
+   - `OPENAI_API_KEY` = your OpenAI API key (required for cloud deployment since local models aren't available)
+4. **Deploy** - Vercel handles the rest
+
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fyorkeccak%2Fbio&env=NEXT_PUBLIC_APP_MODE,VALYU_API_KEY,DAYTONA_API_KEY,OPENAI_API_KEY&envDescription=API%20keys%20needed%20for%20Bio&envLink=https%3A%2F%2Fgithub.com%2Fyorkeccak%2Fbio%23quick-start-self-hosted)
 
 ## Security
 
@@ -257,7 +267,16 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 ## Contributing
 
-Contributions are welcome! Please feel free to submit a Pull Request.
+Contributions are welcome! Here's how to get started:
+
+1. Fork the repository
+2. Create a feature branch (`git checkout -b feature/your-feature`)
+3. Make your changes
+4. Run `pnpm dev` and test locally
+5. Commit your changes and push to your fork
+6. Open a Pull Request against `main`
+
+For bugs or feature requests, [open an issue](https://github.com/yorkeccak/bio/issues) or start a [discussion](https://github.com/yorkeccak/bio/discussions).
 
 ## Acknowledgments
 


### PR DESCRIPTION
## Summary

- Add GitHub badges (stars, license, forks, contributors) at the top
- Update package manager references from npm/yarn to pnpm
- Expand Daytona prerequisite with links and description
- Update architecture section to reference GPT-5.2
- Remove internal-only Valyu Mode (OAuth Coming Soon) section
- Add Vercel deployment section with one-click deploy button
- Expand Contributing section with step-by-step guide and links to issues/discussions

## Test plan

- [ ] Verify badges render correctly on GitHub
- [ ] Confirm Vercel deploy button URL is correct
- [ ] Check all links resolve properly